### PR TITLE
feat: add api docs with scalar

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -19,9 +19,5 @@ Short description of the functional requirement (should link to the requirements
 - 
 - 
 
-## Related user stories (that an epic consists of)
-- #ID
-- #ID
-
 ## Notes
 Important context

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -11,23 +11,10 @@ assignees: ''
 ## Summary
 Short description of what needs to be done.
 
-## Scope
-### What is included:
-- 
-- 
-
-### Out of scope:
-- 
-- 
-
 ## [Acceptance criteria](https://www.atlassian.com/work-management/project-management/acceptance-criteria)
 - [ ] [Condition 1]
 - [ ] [Condition 2]
 - [ ] [Condition 3]
-
-## Implementation tasks list
-- [ ] #PR1
-- [ ] #PR2
 
 ## Notes
 important context

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -15,10 +15,6 @@ As a **_[user type]_** I want **_[goal]_** so that **_[value]_**
 - [ ] [Condition 2]
 - [ ] [Condition 3]
 
-## Implementation tasks list
-- [ ] #PR1
-- [ ] #PR2
-
 ## Visuals (optional)
 screenshots, figma links, etc.
 

--- a/compose.yml
+++ b/compose.yml
@@ -22,7 +22,7 @@
     ports:
       - "5433:5432"
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql
 
   server:
     build:

--- a/server/Directory.Packages.props
+++ b/server/Directory.Packages.props
@@ -19,5 +19,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.13.12" />
+    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.13.12" />
   </ItemGroup>
 </Project>

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -22,6 +22,4 @@ FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-alpine AS prod
 WORKDIR /app
 COPY --from=publish /app/out .
 
-HEALTHCHECK CMD curl --fail http://localhost:3000/health || exit 1
-
 ENTRYPOINT ["dotnet", "Presentation.dll"]

--- a/server/Infrastructure/Extensions/DependencyInjection.cs
+++ b/server/Infrastructure/Extensions/DependencyInjection.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Infrastructure.Extensions;
 
-public static class DependencyInjection
+public static class InfrastructureConfiguration
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {

--- a/server/Infrastructure/Extensions/DependencyInjection.cs
+++ b/server/Infrastructure/Extensions/DependencyInjection.cs
@@ -1,0 +1,27 @@
+﻿using Infrastructure.Identity;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.Extensions;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<AppDbContext>(options =>
+            options.UseNpgsql(configuration.GetConnectionString("DefaultConnection"))
+        );
+
+        services.AddIdentityApiEndpoints<ApplicationUser>(opt =>
+            {
+                opt.User.RequireUniqueEmail = true;
+            })
+            .AddRoles<IdentityRole>()
+            .AddEntityFrameworkStores<AppDbContext>();
+
+        return services;
+    }
+}

--- a/server/Infrastructure/Infrastructure.csproj
+++ b/server/Infrastructure/Infrastructure.csproj
@@ -8,6 +8,9 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
     <Folder Include="Identity\" />
   </ItemGroup>
 </Project>

--- a/server/Presentation/Extensions/DependencyInjection.cs
+++ b/server/Presentation/Extensions/DependencyInjection.cs
@@ -9,7 +9,7 @@ using Scalar.AspNetCore;
 
 namespace Presentation.Extensions;
 
-public static class DependencyInjection
+public static class PresentationConfiguration
 {
     private static IServiceCollection AddPutWikiOpenApi(this IServiceCollection services)
     {

--- a/server/Presentation/Extensions/DependencyInjection.cs
+++ b/server/Presentation/Extensions/DependencyInjection.cs
@@ -9,9 +9,9 @@ using Scalar.AspNetCore;
 
 namespace Presentation.Extensions;
 
-public static class ServiceCollectionExtensions
+public static class DependencyInjection
 {
-    public static IServiceCollection AddPutWikiOpenApi(this IServiceCollection services)
+    private static IServiceCollection AddPutWikiOpenApi(this IServiceCollection services)
     {
         services.AddOpenApi("v1", options =>
         {
@@ -47,9 +47,20 @@ public static class ServiceCollectionExtensions
                     .DisableAgent()
                     .DisableTelemetry()
                     .HideDeveloperTools()
-                    .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient);
+                    .WithDefaultHttpClient(ScalarTarget.JavaScript, ScalarClient.Axios);
             });
         }
         return app;
+    }
+
+    public static IServiceCollection AddWebServices(this IServiceCollection services)
+    {
+        services.AddControllers();
+        services.AddHealthChecks();
+
+        services.AddOpenApi();
+        services.AddPutWikiOpenApi();
+
+        return services;
     }
 }

--- a/server/Presentation/Extensions/ServiceCollectionExtensions.cs
+++ b/server/Presentation/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi;
+
+using Scalar.AspNetCore;
+
+namespace Presentation.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddPutWikiOpenApi(this IServiceCollection services)
+    {
+        services.AddOpenApi("v1", options =>
+        {
+            options.AddScalarTransformers();
+            options.AddDocumentTransformer((document, _, _) =>
+            {
+                document.Info = new OpenApiInfo
+                {
+                    Title = "PutWiki API documentation",
+                    Version = "v1"
+                };
+                return Task.CompletedTask;
+            });
+        });
+
+        return services;
+    }
+
+    public static IApplicationBuilder UsePutWikiOpenApiDocs(this WebApplication app)
+    {
+        if (app.Environment.IsDevelopment())
+        {
+            app.MapOpenApi("/docs/{documentName}.json");
+            app.MapScalarApiReference("/docs", options =>
+            {
+                options
+                    .WithOpenApiRoutePattern("/docs/{documentName}.json")
+                    .AddDocument("v1")
+                    .WithTitle("PutWiki API documentation")
+                    .ForceDarkMode()
+                    .SortTagsAlphabetically()
+                    .SortOperationsByMethod()
+                    .DisableAgent()
+                    .DisableTelemetry()
+                    .HideDeveloperTools()
+                    .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient);
+            });
+        }
+        return app;
+    }
+}

--- a/server/Presentation/Presentation.csproj
+++ b/server/Presentation/Presentation.csproj
@@ -5,6 +5,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Scalar.AspNetCore" />
+    <PackageReference Include="Scalar.AspNetCore.Microsoft" />
   </ItemGroup>
 
   <ItemGroup>

--- a/server/Presentation/Program.cs
+++ b/server/Presentation/Program.cs
@@ -1,10 +1,12 @@
 using Infrastructure;
 using Infrastructure.Identity;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+
 using Presentation.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/server/Presentation/Program.cs
+++ b/server/Presentation/Program.cs
@@ -1,12 +1,10 @@
 using Infrastructure;
 using Infrastructure.Identity;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -26,21 +24,15 @@ builder
     .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<AppDbContext>();
 
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+
+builder.Services.AddPutWikiOpenApi();
 
 var app = builder.Build();
-
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-}
 
 app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapHealthChecks("/health");
-
 app.MapControllers();
 
 await app.RunAsync();

--- a/server/Presentation/Program.cs
+++ b/server/Presentation/Program.cs
@@ -1,41 +1,24 @@
-using Infrastructure;
+using Infrastructure.Extensions;
 using Infrastructure.Identity;
 
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Routing;
 
 using Presentation.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
-
-builder.Services.AddHealthChecks();
-
-builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection"))
-);
-
-builder
-    .Services.AddIdentityApiEndpoints<ApplicationUser>(opt =>
-    {
-        opt.User.RequireUniqueEmail = true;
-    })
-    .AddRoles<IdentityRole>()
-    .AddEntityFrameworkStores<AppDbContext>();
-
-builder.Services.AddPutWikiOpenApi();
+builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddWebServices();
 
 var app = builder.Build();
 
 app.UseAuthentication();
-app.UsePutWikiOpenApiDocs();
 app.UseAuthorization();
+app.UsePutWikiOpenApiDocs();
 
 app.MapHealthChecks("/health");
+app.MapIdentityApi<ApplicationUser>();
 app.MapControllers();
 
 await app.RunAsync();

--- a/server/Presentation/Program.cs
+++ b/server/Presentation/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Presentation.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -24,12 +25,12 @@ builder
     .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<AppDbContext>();
 
-
 builder.Services.AddPutWikiOpenApi();
 
 var app = builder.Build();
 
 app.UseAuthentication();
+app.UsePutWikiOpenApiDocs();
 app.UseAuthorization();
 
 app.MapHealthChecks("/health");

--- a/server/Presentation/Properties/launchSettings.json
+++ b/server/Presentation/Properties/launchSettings.json
@@ -4,7 +4,8 @@
     "dev": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
+      "launchUrl": "docs",
       "applicationUrl": "http://localhost:7278",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/server/README.md
+++ b/server/README.md
@@ -4,7 +4,15 @@ The server side app written in ASP.NET Core (C#).
 
 ## Architecture overview
 
-**PLACEHOLDER**
+The project follows the principles of **Clean Architecture**, separating concerns into distinct layers:
+
+* **Domain:** Contains enterprise logic, core entities, and custom exceptions. It has no dependencies on other layers or external frameworks.
+* **Application:** Holds the business logic, use cases, and interfaces. It orchestrates the flow of data to and from the Domain layer.
+* **Infrastructure:** Implements external concerns like database access (Entity Framework Core), Identity, and third-party integrations.
+* **Presentation:** The entry point of the application (Web API). It contains controllers, global error handling, validation and API endpoints.
+
+> [!NOTE]
+> **API Documentation:** When running in the development environment, interactive API documentation is available at the `/docs` endpoint.
 
 ## How to run (dev)?
 


### PR DESCRIPTION
## Changes
- add api docs in scalar available at `/docs` on dev enviroment
- use extension methods to better organize Program.cs
- map identity service endpoints
- migrate to postgres 18 new data directory (see [this](https://github.com/docker-library/postgres/pull/1259))

## How to test (optional)
Steps for reviewer to verify changes.

## Screenshots / recordings (for UI stuff)
...

## Checklist
- [x] PR is linked to an issue (tab on the right).
- [x] Acceptance criteria (from issue) are met.
- [x] All status checks (CI) are green.
- [x] Tests added / updated.
- [x] Docs updated (if applicable).

---
To have your PR reviewed put the link e.g. `https://github.com/akai-org/put-wiki/pull/0` to the `Review PR` thread on [put-wiki dc channel](https://discord.com/channels/768494845634412624/1467612224079007855) (you must be member of the AKAI discord server)
