### PR TITLE
chore: add server and db health checks

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -7,12 +7,15 @@
       - "80:80"
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
-    depends_on:
-      - client
-      - server
     networks:
       - app_network
     restart: unless-stopped
+    depends_on:
+      client:
+        condition: service_started
+      server:
+        condition: service_healthy
+
   database:
     image: postgres:18
     container_name: database
@@ -22,7 +25,13 @@
     ports:
       - "5433:5432"
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]      
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
   server:
     build:
@@ -35,17 +44,29 @@
     networks:
       - app_network
     restart: unless-stopped
+    volumes:
+      - aspnet_keys:/root/.aspnet/DataProtection-Keys
+    depends_on:
+      database:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:$${ASPNETCORE_HTTP_PORTS}/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
 
   client:
     build:
       context: ./client
       target: prod
     container_name: client
-    depends_on:
-      - server
     networks:
       - app_network
     restart: unless-stopped
+    depends_on:
+      server:
+        condition: service_healthy
 
 networks:
   app_network:
@@ -53,3 +74,4 @@ networks:
 
 volumes:
   db_data:
+  aspnet_keys:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -20,6 +20,7 @@ RUN dotnet publish "Presentation/Presentation.csproj" -c Release -o /app/out --n
 
 FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-alpine AS prod
 WORKDIR /app
+RUN apk add --no-cache curl
 COPY --from=publish /app/out .
 
 HEALTHCHECK CMD curl --fail http://localhost:3000/health || exit 1


### PR DESCRIPTION
## Changes
- server and db have health checks configured in docker compose
- server image has curl added
- new docker volume that stores asp.net keys (DataProtection keys).

## How to test (optional)
To test just run `docker compose up` and `docker ps`. Server and database should have "healthy" labels.
Docker compose docs about healthchecks: https://docs.docker.com/compose/how-tos/startup-order/

Logs that shown me the need to add docker volume:
```
server    | warn: Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository[60]
server    |       Storing keys in a directory '/root/.aspnet/DataProtection-Keys' that may not be persisted outside of the container. Protected data will be unavailable when container is destroyed. For more information go to https://aka.ms/aspnet/dataprotectionwarning
server    | warn: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[35]
server    |       No XML encryptor configured. Key may be persisted to storage in unencrypted form.
```

But keys are still unencrypted (I think that it's ok currently)

## Screenshots / recordings (for UI stuff)
...

## Checklist
- [x] PR is linked to an issue (tab on the right).
- [x] Acceptance criteria (from issue) are met.
- [x] All status checks (CI) are green.
- [x] Tests added / updated.
- [x] Docs updated (if applicable).

---
To have your PR reviewed put the link e.g. `https://github.com/akai-org/put-wiki/pull/0` to the `Review PR` thread on [put-wiki dc channel](https://discord.com/channels/768494845634412624/1467612224079007855) (you must be member of the AKAI discord server)
