### PR TITLE
docs: add ADR-s for the most significant backend decisions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build matrix
         id: set-matrix
         run: |
-          matrix=$(jq -n '{include: []}')
+          matrix=$(jq -nc '{include: []}')
 
           if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ steps.filter.outputs.actions }}" == "true" ]]
           then
@@ -98,7 +98,7 @@ jobs:
         with:
           category: "/language:${{matrix.language}}"
 
-  analysis-status: 
+  analysis-status:
     name: Analysis status
     needs: [prepare-matrix, analyze]
     runs-on: ubuntu-latest

--- a/docs/architecture/adr/000-ADR-TEMPLATE.md
+++ b/docs/architecture/adr/000-ADR-TEMPLATE.md
@@ -1,16 +1,13 @@
-# ADR-001 XXXX — Title
-
-## Date
-YYYY-MM-DD
+# [BE/FE]-001 XXXX — Title
 
 ## Status
-**Proposed** | Accepted | Deprecated
+Proposed | Accepted | Deprecated | Superseded
 
 ## Context
-Dlaczego potrzebujemy decyzji.
+The context in which the decision was made, including the problem statement, constraints, and requirements.
 
 ## Decision
-Co zostało postanowione.
+The decision itself.
 
 ## Consequences
 ### (+):
@@ -24,7 +21,11 @@ Co zostało postanowione.
 - ...
 
 ## Alternatives
-Rozważane opcje i powody odrzucenia.
+Considered options and why we rejected them:
 1. ...
 2. ...
 3. ...
+
+## Links to external or internal resources
+- [Demystifying Architectural Decision Records: Why Every Project Needs Them by Daniel Mackay](https://www.dandoescode.com/blog/demystifying-architectural-decision-records-why-every-project-needs-them)
+- [Documenting Architecture Decisions by Michael Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions.html)

--- a/docs/architecture/adr/BE-001_dependency-inversion-and-domain-isolation.md
+++ b/docs/architecture/adr/BE-001_dependency-inversion-and-domain-isolation.md
@@ -6,7 +6,7 @@ Proposed
 ## Context
 We are starting this project from scratch. The architectural decisions we make today will dictate how quickly we can add features a year from now.
 
-In traditional architectures (e.g. standard layered architecture), the database sits at the bottom, and everything else depends on it. This inevitably leads to a situation where core business rules become entangled with database specifics (like SQL queries or ORM configurations) and HTTP concerns. As a result, the code becomes difficult to unit test, hard to understand, and expensive to change.
+In traditional architectures (e.g. standard layered architecture), the business logic often becomes coupled to data access details. This inevitably leads to a situation where core business rules become entangled with database specifics (like SQL queries or ORM configurations) and HTTP concerns. As a result, the code becomes difficult to unit test, hard to understand, and expensive to change.
 
 Since we are building a long-term software, we need a foundation that prioritizes and protects our core business logic from the very beginning, keeping it isolated from external technologies, frameworks, and infrastructure.
 

--- a/docs/architecture/adr/BE-001_dependency-inversion-and-domain-isolation.md
+++ b/docs/architecture/adr/BE-001_dependency-inversion-and-domain-isolation.md
@@ -1,0 +1,71 @@
+# BE-001 Architecture style: dependency inversion & domain isolation
+
+## Status
+Proposed
+
+## Context
+We are starting this project from scratch. The architectural decisions we make today will dictate how quickly we can add features a year from now.
+
+In traditional architectures (e.g. standard layered architecture), the database sits at the bottom, and everything else depends on it. This inevitably leads to a situation where core business rules become entangled with database specifics (like SQL queries or ORM configurations) and HTTP concerns. As a result, the code becomes difficult to unit test, hard to understand, and expensive to change.
+
+Since we are building a long-term software, we need a foundation that prioritizes and protects our core business logic from the very beginning, keeping it isolated from external technologies, frameworks, and infrastructure.
+
+## Decision
+We will adopt an architecture based on **dependency inversion** and **domain isolation** (drawing heavily from clean and hexagonal architectures).
+
+The fundamental rule of this architecture is the **dependency rule:** __source code dependencies must always point inward, toward the core business logic.__
+
+To achieve this, we divide our application into four distinct, concentric layers (from the inside out):
+
+1. **Domain layer (the core):** Contains our business rules, aggregates, entities, and value objects.
+
+    - **Rule:** it has zero dependencies on anything outside of itself. It does not know about databases, JSON, or APIs. 
+    
+    - **NOTE:** we decided to use small library `FluentResults` in our Domain layer. We treat it as a language primitive. More about Result pattern and error handling in this project [here](docs\architecture\adr\BE-004_error-handling-and-flow-control.md)
+
+2. **Application layer (use cases):** contains the specific workflows of our system (e.g., `ProvisionUserUseCase`, `UpdateUserNicknameUseCase`).
+
+    - **Rule:** it depends only on the Domain layer. When it needs to save data or talk to an external API, it defines an **interface** (e.g., `IUserRepository`). It does not implement this interface.
+
+3. **Infrastructure layer:** this is where the actual technologies live (e.g., EF Core, third-party API clients, file system access, etc).
+
+    - **Rule:** it implements the interfaces defined by the Application layer (this is the __dependency inversion__).
+
+4. **Presentation / API layer:** contains our HTTP controllers, endpoints, and JSON serialization.
+
+    - **Rule:** it receives web requests, validates the HTTP payload, and simply delegates the work to the use cases in the Application layer.
+
+## Consequences
+### (+):
+- **Delayed infrastructure decisions:** because the core logic relies on interfaces rather than concrete databases, we can for example start writing and testing business features on day 1 using simple in-memory mock repositories, long before we even decide on a database schema.
+
+- **High testability:** since the Domain and Application layers have no dependencies on external frameworks, we can write lightning-fast unit tests for our business rules without needing to spin up a database or web server.
+
+- **Clear boundaries (no spaghetti code):** new developers have a strict, predictable mental model. You cannot accidentally query the database directly from a controller, which prevents the codebase from degrading into a tangled mess as the team scales. Moreover as Domain layer is written purely in C# without framework code it makes easier for new teammates to understand app's core logic.
+
+### (-):
+- **Higher initial boilerplate:** for a new project, this architecture requires creating more files upfront. Instead of one class handling everything, a single feature might require a domain entity, a data transfer object (DTO), an interface, use case and a mapping configuration.
+
+- **Steeper learning curve:** new team members accustomed to traditional "fat controllers" or mixing SQL concerns directly into their services will need time to adjust to strictly separated layers.
+
+- **Overhead for simple CRUD:** basic operations that just read or write a single record without any complex business rules will feel over-engineered, as the data still has to travel through all the architectural layers.
+
+## Alternatives
+Considered options and why we rejected them:
+
+1. **Traditional n-tier (controller -> service -> repository):** Rejected. In this model, the database is the foundation. While it is faster to set up initially, it tightly couples business logic to the database technology. This encourages an __"anemic domain model"__ (where business objects are just bags of getters/setters with no logic) and forces developers to write slow, fragile integration tests instead of fast unit tests.
+
+2. **Standard MVC (model-view-controller):** Rejected. MVC is primarily a UI delivery pattern, not a system-wide architecture. Using it as the sole blueprint for a modern backend API inevitably leads to bloated controllers and models that mix HTTP validation, database mapping, and core business rules in the same files.
+
+## Links to external or internal resources
+- [The Clean Architecture by Robert C. Martin](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) - the foundational article explaining the Dependency Rule.
+
+- [Hexagonal Architecture (aka ports and adapters) by Alistair Cockburn](https://alistair.cockburn.us/hexagonal-architecture) - original article that explains the concept of isolating the core logic using interfaces.
+
+- [Common web application architectures by Microsoft](https://learn.microsoft.com/en-us/dotnet/architecture/modern-web-apps-azure/common-web-application-architectures) - about monolithic applications, layers and clean architecture
+
+- [Unpacking the Layers of Clean Architecture – Domain, Application, and Infrastructure Services by Daniel Mackay](https://www.dandoescode.com/blog/unpacking-the-layers-of-clean-architecture-domain-application-and-infrastructure-services) - clean architecture overview and what the term __service__ means depending on layer.
+
+- [The Software Architecture Chronicles by Herberto Graça](https://herbertograca.com/2017/07/03/the-software-architecture-chronicles/) - in depth overview about different software architecture starting from the beginning of software engineering. The one that summarizes everything is [here](https://herbertograca.com/2017/11/16/explicit-architecture-01-ddd-hexagonal-onion-clean-cqrs-how-i-put-it-all-together/)
+
+- [Hexagonal Architecture [Onion/Ports & Adapters] by Bartosz Dąbek](https://www.bdabek.pl/architektura-hexagonalna/) - in Polish

--- a/docs/architecture/adr/BE-001_dependency-inversion-and-domain-isolation.md
+++ b/docs/architecture/adr/BE-001_dependency-inversion-and-domain-isolation.md
@@ -1,7 +1,7 @@
 # BE-001 Architecture style: dependency inversion & domain isolation
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 We are starting this project from scratch. The architectural decisions we make today will dictate how quickly we can add features a year from now.

--- a/docs/architecture/adr/BE-002_lightweight-domain-driven-design-and-repo-pattern.md
+++ b/docs/architecture/adr/BE-002_lightweight-domain-driven-design-and-repo-pattern.md
@@ -1,7 +1,7 @@
 # BE-002 Lightweight domain driven design and repository pattern
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 In many standard web applications, business rules (e.g., "A student cannot review a course they haven't taken," or "A university course must have at least one tutor") end up scattered across UI controllers, application services, or even database triggers.

--- a/docs/architecture/adr/BE-002_lightweight-domain-driven-design-and-repo-pattern.md
+++ b/docs/architecture/adr/BE-002_lightweight-domain-driven-design-and-repo-pattern.md
@@ -1,0 +1,60 @@
+# BE-002 Lightweight domain driven design and repository pattern
+
+## Status
+Proposed
+
+## Context
+In many standard web applications, business rules (e.g., "A student cannot review a course they haven't taken," or "A university course must have at least one tutor") end up scattered across UI controllers, application services, or even database triggers.
+
+Furthermore, data objects often take the form of an **anemic domain model** - they are just "bags of properties" with public getters and setters (e.g., `user.Status = "Banned"`). This allows any piece of code anywhere in the system to modify the data directly. Over time, this guarantees data inconsistency and bugs, because developers forget to call the required validation checks before changing the state.
+
+We need a systematic approach to model our core business rules directly within the data structures they govern, ensuring that it is physically impossible for the system to enter an invalid state.
+
+## Decision
+We will adopt lightweight **Domain-Driven Design** concepts combined with the **Repository pattern**.
+
+- **Rich domain models:** our core entities will be "smart". They will guard their own rules (invariants). We will strictly forbid public setters on properties. State changes will only be allowed via specific, behavior-rich business methods (e.g., `user.Ban(reason)` instead of `user.Status = "Banned"`).
+
+- **Value Objects:** we will use immutable Value Objects to encapsulate small, coherent pieces of logic. For example, instead of storing a grade as an `int`, we will create a `Grade` value object that internally guarantees it can only ever hold a value between 2.0 and 5.0.
+
+- **Aggregates:** we will group related entities into single transaction boundaries called Aggregates (e.g., a `Course` and its `Reviews` might form one Aggregate).
+
+- **Repository pattern:** we will use Repositories __exclusively__ to save and retrieve these Aggregates from the database. The rest of the application will ask the Repository for an Aggregate, call a business method on it, and tell the Repository to save it.
+
+## Consequences
+### (+):
+- **Guaranteed consistency:** because there are no public setters, you cannot bypass the business rules. It becomes impossible to create an invalid domain object.
+
+- **High cohesion:** data and the exact logic that modifies it live in the exact same file. This makes debugging incredibly fast.
+
+- **Expressive code (Ubiquitous Language):** The code in Domain layer reads like plain English and uses the language of the university domain (e.g., `course.AssignTutor(tutorId)` instead of `course.TutorId = tutorId`).
+
+### (-):
+- **Mapping overhead:** our ORM (EF Core) sometimes struggles to save highly complex, encapsulated domain entities directly to database tables. We may occasionally need to write mapping code to translate our pure domain entity into a database-friendly structure.
+
+- **Performance considerations:** To update a single property (e.g., changing a review status), we must load the entire Aggregate from the database into memory, execute the logic, and save it back. This is slightly slower than executing a raw SQL `UPDATE` statement.
+
+## Alternatives
+Considered options and why we rejected them:
+
+1. **Anemic domain model with logic in services:** Rejected. Moving all validation logic to Application layer services makes the entities "dumb". This inevitably leads to code duplication (e.g., two different services both implement the logic to calculate an average score, doing it slightly differently) and missed validations.
+
+2. **Active record pattern:** Rejected. Tying database access methods directly to the entity itself (e.g., `user.SaveToDb()`) violates the Single Responsibility Principle and couples our pure domain logic directly to database concerns.
+
+3. **Full DDD with event sourcing:** Rejected. While powerful, it is massive over-engineering for our current scale. Event sourcing introduces immense operational and debugging complexity (event stores, eventual consistency) that a new project does not need.
+
+## Links to external or internal resources
+
+- [Anemic Domain Model by Martin Fowler](https://martinfowler.com/bliki/AnemicDomainModel.html) - explains why objects with only getters and setters are an anti-pattern.
+
+- [Design a microservice domain model by Microsoft](https://learn.microsoft.com/en-us/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/microservice-domain-model) - In-depth guide to implementation of DDD concepts  like Aggregates and Value Objects in .NET. Contains lots of useful references to other resources.
+
+- [DDD Modelling - Aggregates vs Entities: A Practical Guide by Daniel Mackay](https://www.dandoescode.com/blog/ddd-modelling-aggregates-vs-entities)
+
+- [Domain Driven Design: Patterns for Aggregate Creation Mastery](https://www.dandoescode.com/blog/domain-driven-design-patterns-for-aggregate-creation-mastery)
+
+- [Domain-Driven Design by Herberto Graça](https://herbertograca.com/2017/09/07/domain-driven-design/)
+
+- [Domain Driven Design by Bartosz Dąbek](https://www.bdabek.pl/domain-driven-design/) - in Polish
+
+- [Anemic Domain Model vs Rich Domain Model - What is it? by Bartosz Dąbek](https://www.bdabek.pl/anemic-domain-model-vs-rich-domain-model/) - in Polish

--- a/docs/architecture/adr/BE-002_lightweight-domain-driven-design-and-repo-pattern.md
+++ b/docs/architecture/adr/BE-002_lightweight-domain-driven-design-and-repo-pattern.md
@@ -8,7 +8,7 @@ In many standard web applications, business rules (e.g., "A student cannot revie
 
 Furthermore, data objects often take the form of an **anemic domain model** - they are just "bags of properties" with public getters and setters (e.g., `user.Status = "Banned"`). This allows any piece of code anywhere in the system to modify the data directly. Over time, this guarantees data inconsistency and bugs, because developers forget to call the required validation checks before changing the state.
 
-We need a systematic approach to model our core business rules directly within the data structures they govern, ensuring that it is physically impossible for the system to enter an invalid state.
+We need a systematic approach to model our core business rules directly within the data structures they govern, ensuring that it is significantly harder to create an invalid state through the domain model.
 
 ## Decision
 We will adopt lightweight **Domain-Driven Design** concepts combined with the **Repository pattern**.

--- a/docs/architecture/adr/BE-003_read-and-write-separation.md
+++ b/docs/architecture/adr/BE-003_read-and-write-separation.md
@@ -15,7 +15,7 @@ We will cleanly separate our read and write execution paths, adopting a simplifi
 
 - **Writes (Commands / Use Cases):** When state changes (e.g., submitting a review, registering a user), the request will go through a Use Case, load the Domain Aggregate via the Repository, execute business rules, and save via Entity Framework with change-tracking enabled.
 
-- **Reads (Queries):** When data is only being displayed (e.g., fetching a list of top-rated courses), the request will bypass the Domain layer and Repositories entirely. We will inject the EF Core `DbContext` directly into a Query class, use it in strictly read-only mode (`.AsNoTracking()`), and project the raw SQL data directly into flat Data Transfer Objects (DTOs) using LINQ.
+- **Reads (Queries):** When data is only being displayed (e.g., fetching a list of top-rated courses), the request will bypass the Domain layer and Repositories entirely. We will inject the EF Core `DbContext` directly into a Query class, use it in strictly read-only mode (`.AsNoTracking()`), and project query results into flat DTOs using LINQ translated by EF Core.
 
 - **Explicit execution (without MediatR):** we will implement explicit Handler classes (e.g., CreateUserUseCase, GetCourseDetailsQueryHandler) and inject them directly into our API endpoints via Dependency Injection. We will not use in-memory buses like MediatR to avoid unnecessary abstraction at the beginning.
 

--- a/docs/architecture/adr/BE-003_read-and-write-separation.md
+++ b/docs/architecture/adr/BE-003_read-and-write-separation.md
@@ -1,7 +1,7 @@
 # BE-003 Read and write separation
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 In [BE-002 ADR](docs\architecture\adr\BE-002_lightweight-domain-driven-design-and-repo-pattern.md), we established that we will use Rich Domain Models and Repositories to guarantee data consistency. This means when we want to modify data (a write), we load a full object into memory, track changes, and validate rules.

--- a/docs/architecture/adr/BE-003_read-and-write-separation.md
+++ b/docs/architecture/adr/BE-003_read-and-write-separation.md
@@ -1,0 +1,45 @@
+# BE-003 Read and write separation
+
+## Status
+Proposed
+
+## Context
+In [BE-002 ADR](docs\architecture\adr\BE-002_lightweight-domain-driven-design-and-repo-pattern.md), we established that we will use Rich Domain Models and Repositories to guarantee data consistency. This means when we want to modify data (a write), we load a full object into memory, track changes, and validate rules.
+
+However, most of web traffic consists of simple reads - users just looking at data (e.g., viewing a list of courses, looking at a user profile). Using our Repositories and Rich Domain Models for simple UI reads is highly inefficient. It forces Entity Framework to track changes (which consumes memory) and requires us to map complex aggregates down to simple UI objects.
+
+We need a performant way to query data for the UI without polluting our strict, write-focused Domain layer with database join queries and UI-specific properties.
+
+## Decision
+We will cleanly separate our read and write execution paths, adopting a simplified version of **Command Query Responsibility Segregation (CQRS)**.
+
+- **Writes (Commands / Use Cases):** When state changes (e.g., submitting a review, registering a user), the request will go through a Use Case, load the Domain Aggregate via the Repository, execute business rules, and save via Entity Framework with change-tracking enabled.
+
+- **Reads (Queries):** When data is only being displayed (e.g., fetching a list of top-rated courses), the request will bypass the Domain layer and Repositories entirely. We will inject the EF Core `DbContext` directly into a Query class, use it in strictly read-only mode (`.AsNoTracking()`), and project the raw SQL data directly into flat Data Transfer Objects (DTOs) using LINQ.
+
+- **Explicit execution (without MediatR):** we will implement explicit Handler classes (e.g., CreateUserUseCase, GetCourseDetailsQueryHandler) and inject them directly into our API endpoints via Dependency Injection. We will not use in-memory buses like MediatR to avoid unnecessary abstraction at the beginning.
+
+- **Command/Query objects:** handlers will accept a single, strongly-typed wrapper record (e.g., `CreateUserCommand(string Name, string Email)`) rather than a list of primitive parameters. This future-proofs method signatures and encapsulates request data.
+
+## Consequences
+### (+):
+- **High performance:** Read operations become blazing fast. Bypassing ORM tracking and projecting directly to flat DTOs saves CPU cycles and memory.
+
+- **Separation of concerns:** The UI often requires data aggregated from many tables. By separating reads, we don't have to ruin our core Domain model by adding UI-specific properties just to satisfy the frontend.
+
+- **Simpler code for reads:** Retrieving data becomes a straightforward LINQ-to-SQL query. No complex repository abstractions are needed.
+
+### (-):
+- **Model duplication:** we will have separate representations of the same concepts (e.g., a User domain entity for logic, and a UserProfileDto for display).
+
+- **Mental shift** developers must consciously decide whether a new feature modifies state (a Command) or fetches data (a Query) and place the code in the correct logical bucket.
+
+## Alternatives
+Considered options and why we rejected them:
+
+1. **MediatR / in-memory message bus:** Rejected. while popular, it obscures the execution path behind reflection/dynamic dispatch. Explicitly injecting Use Case classes makes the codebase easier to trace and debug for a team just starting out.
+
+2. **Full CQRS with Event Sourcing & separate read database:** Rejected. Over-engineering for a greenfield project. Maintaining two separate physical databases (one for writes, one synchronized for reads) introduces eventual consistency and infrastructure complexity we do not need right now.
+
+## Links to external or internal resources
+- [CQRS Pattern by Microsoft](https://learn.microsoft.com/en-us/azure/architecture/patterns/cqrs) - explains the separation of read and write data stores or models. Also includes section about event sourcing (we won't use it in our project).

--- a/docs/architecture/adr/BE-004_error-handling-and-flow-control.md
+++ b/docs/architecture/adr/BE-004_error-handling-and-flow-control.md
@@ -1,0 +1,47 @@
+# BE-004 Error handling and flow control with Result pattern
+
+## Status
+Proposed
+
+## Context
+In traditional C# development, it is common to throw exceptions for business validation failures (e.g., `throw new Exception("Nickname is already taken.")`).
+
+However, exceptions in .NET are designed for exceptional, unforeseen circumstances (like the database server crashing, or running out of memory). Using exceptions for standard, expected control flow (like a user providing a bad password) is computationally expensive because the runtime must gather a full system stack trace.
+
+Furthermore, using exceptions for logic scatters `try-catch` blocks throughout the Application layer. It makes the code execution flow unpredictable (like `goto` statements), and forces developers to guess which methods might throw which exceptions.
+
+## Decision
+We will use the Result pattern for all expected business errors and domain validations, while strictly retaining exceptions for developer errors and system failures.
+
+- **Explicit returns:** Domain methods and Application Use Cases will never return void. They will return a `Result` or `Result<T>` object. This object will clearly encapsulate either a successful outcome containing data, or an explicit failure state containing an error message.
+
+- **Domain errors (Result):** Domain methods and Application Use Cases will return a `Result` or `Result<T>` object for business rule violations (e.g., "Nickname is taken"). This explicitly communicates failure states to the caller.
+
+- **Developer errors & bugs (exceptions):** we will continue to throw standard exceptions (e.g., `ArgumentNullException`, `ArgumentException`, `InvalidOperationException`) to enforce programming contracts. If a method requires a non-null parameter and receives null, it should throw immediately. These represent bugs in the code, not user errors, and will be caught by global middleware to return a 500 error.
+
+## Consequences
+### (+):
+- **Better performance:** We completely avoid the massive performance penalty of generating stack traces for normal, everyday business rule violations.
+
+- **Explicit contracts:** Method signatures tell the whole story. If you see `public Result<User> CreateUser(...)`, you know immediately, without looking at the implementation, that this operation can fail.
+
+- **Cleaner application flow:** We eliminate nested, ugly `try-catch` blocks. The code reads sequentially with clean guard clauses (e.g., `var result = course.Enroll(); if (result.IsFailure) return result;`).
+
+### (-):
+- **Boilerplate code:** it requires wrapping standard return types in the `Result<T>` generic class, and constantly checking the `.IsFailure` or `.IsSuccess` flags after calling domain methods.
+
+- **Mental distinction required:** Developers must learn the difference between a "domain error" (handled via `Result`) and a "developer/system error" (handled via exceptions).
+
+## Alternatives
+Considered options and why we rejected them:
+
+1. Throwing Exceptions for all errors: Rejected. Causes performance hits and forces the Application layer to use `try-catch` blocks as a control flow mechanism, making the code harder to read and maintain.
+
+2. Returning `null` or boolean (`true`/`false`): Rejected. While fast, it fails to provide sufficient context. A `false` return does not explain why an operation failed (e.g., whether the nickname was too short, or already taken), making it impossible to return a helpful message to the user.
+
+## Links to external or internal resources
+- [Exceptions for flow control in C# by Vladimir Khorikov](https://enterprisecraftsmanship.com/posts/exceptions-for-flow-control/)
+
+- [What is an exceptional situation in code? by Vladimir Khorikov](https://enterprisecraftsmanship.com/posts/what-is-exceptional-situation/)
+
+- [Error handling: Exception or Result? by Vladimir Khorikov](https://enterprisecraftsmanship.com/posts/error-handling-exception-or-result/) - A deep dive into why exceptions should not be used for expected business failures.

--- a/docs/architecture/adr/BE-004_error-handling-and-flow-control.md
+++ b/docs/architecture/adr/BE-004_error-handling-and-flow-control.md
@@ -1,7 +1,7 @@
 # BE-004 Error handling and flow control with Result pattern
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 In traditional C# development, it is common to throw exceptions for business validation failures (e.g., `throw new Exception("Nickname is already taken.")`).

--- a/docs/architecture/adr/BE-004_error-handling-and-flow-control.md
+++ b/docs/architecture/adr/BE-004_error-handling-and-flow-control.md
@@ -6,7 +6,7 @@ Proposed
 ## Context
 In traditional C# development, it is common to throw exceptions for business validation failures (e.g., `throw new Exception("Nickname is already taken.")`).
 
-However, exceptions in .NET are designed for exceptional, unforeseen circumstances (like the database server crashing, or running out of memory). Using exceptions for standard, expected control flow (like a user providing a bad password) is computationally expensive because the runtime must gather a full system stack trace.
+However, exceptions in .NET are designed more for exceptional circumstances (like the database server crashing, or running out of memory) or for breaches of contracts and programming errors (using `ArgumentException`, `InvalidOperationException` etc). Using exceptions for standard, expected control flow (like a user providing a bad password) is computationally expensive because the runtime must gather a full system stack trace.
 
 Furthermore, using exceptions for logic scatters `try-catch` blocks throughout the Application layer. It makes the code execution flow unpredictable (like `goto` statements), and forces developers to guess which methods might throw which exceptions.
 

--- a/docs/architecture/adr/BE-005_monolithic-application.md
+++ b/docs/architecture/adr/BE-005_monolithic-application.md
@@ -4,16 +4,20 @@
 Proposed
 
 ## Context
-We are currently starting promising project with four primary business areas identified so far: Users, Lecturers, Opinions, and Courses. We have already adopted Clean Architecture, lightweight Domain-Driven Design (DDD), and simple CQRS to maintain strict technical boundaries between our business logic and infrastructure.
+We are currently starting a promising project with four primary business areas identified so far: Users, Lecturers, Opinions, and Courses. We have already adopted Clean Architecture, lightweight Domain-Driven Design (DDD), and simple CQRS to maintain strict technical boundaries between our business logic and infrastructure.
 
-We now need to decide on the high-level deployment and structural boundary of the system. While advanced patterns like microservices or modular monoliths offer excellent long-term scalability and strict domain isolation, we must balance this against our current constraints: a small student team, the need for rapid prototyping, and the reality that our domain boundaries are still evolving and might change as we discover new requirements.
+We now need to decide on the high-level deployment and structural boundary of the system. While patterns such as modular monoliths and microservices can provide stronger module isolation and independent scalability, they also introduce additional complexity that may not be justified at our current stage.
+
+Our team is relatively small, the product requirements are still evolving, and the boundaries between business domains are not yet fully understood. We therefore need an architecture that maximizes development speed and simplicity while still allowing future evolution toward stricter modularization if the project grows.
 
 ## Decision
 We will build the backend as a **standard monolith with logical boundaries** (a single deployment unit and a single database context).
 
-- **Deployment:** the entire backend will be compiled and deployed as a single ASP.NET Core application.
-- **Data access:** we will use a single Entity Framework Core `DbContext` to allow for easy querying and joining of data across different business entities during our initial development phases.
-- **Organization:** while we won't enforce strict physical compilation boundaries between modules yet, we will organize our Application and Domain layers by feature or domain aggregate (e.g., grouping all Course-related Use Cases, domain entities, and interfaces in a dedicated `Courses` directory) to prepare for future extraction.
+- **Deployment:** the entire backend will be compiled, tested, and deployed as a single ASP.NET Core application.
+- **Data access:** we will use a single Entity Framework Core DbContext and a single relational database during the initial phases of development.
+- **Organization:** the codebase will be organized by business capabilities and aggregates (e.g., Courses, Users, Opinions, Lecturers) rather than technical layers alone.
+- **Domain boundaries:** despite sharing a codebase and database, we will strive to keep business concepts separated and avoid unnecessary coupling between domains.
+- **Future evolution:** if specific domains become significantly larger, require independent deployment, or demonstrate clear ownership boundaries, we will evaluate a transition toward a modular monolith.
 
 ## Consequences
 
@@ -24,8 +28,9 @@ We will build the backend as a **standard monolith with logical boundaries** (a 
 - **Paves the way for the future:** Because we are using Clean Architecture [BE-001](docs\architecture\adr\BE-001_dependency-inversion-and-domain-isolation.md), our core logic is already decoupled from the infrastructure. This makes transitioning to a modular monolith much easier later when the project size justifies it.
 
 ### (-):
-- **Risk of coupling:** without strict compiler-level enforcement, developers might become lazy and tightly couple the Opinions logic directly to the Users logic. This requires strict discipline during code reviews to ensure domain aggregates only reference each other by ID, not by direct object references.
-- **Future migration effort:** when the time comes to split into a modular monolith, we will have to carefully untangle any cross-domain database queries that we allowed early on.
+- **Risk of accidental coupling:** because all domains exist in the same codebase and database, developers can create dependencies that blur business boundaries if code reviews are not disciplined.
+- **Growing maintenance cost:** as the application expands, build times, deployment times, and the complexity of understanding the entire system may increase.
+- **Single deployment unit:** even small changes require redeploying the entire application.
 - **Single point of failure:** if one feature causes a memory leak or crashes the application, the entire API goes down.
 
 ## Alternatives
@@ -33,7 +38,7 @@ Considered options and why we rejected them:
 
 1. **Microservices architecture:** Rejected. Absolute overkill for a student project. It introduces immense distributed systems complexity (network latency, distributed tracing, eventual consistency, multiple CI/CD pipelines, container orchestration) that would completely halt our actual feature development.
 
-2. **Modular monolith:** Rejected for now. A true modular monolith requires strict data isolation (separate database schemas or contexts per module) and explicit APIs for modules to talk to each other. Given that our domains (Users, Courses, Opinions, Lecturers) are highly interconnected, implementing this from beginning would introduce too much friction. We will revisit this pattern when specific modules become large enough to warrant physical isolation.
+2. **Modular monolith:** Rejected for now. A modular monolith is a strong architectural option that enforces clear boundaries between modules within a single deployment unit. Given that our domains (Users, Courses, Opinions, Lecturers) are highly interconnected, implementing this from beginning would introduce too much friction and slow down development. We will revisit this pattern when specific modules become large enough and well-understood to warrant physical isolation.
 
 ## Links to external or internal resources
 - [MonolithFirst by Martin Fowler](https://martinfowler.com/bliki/MonolithFirst.html) - Explains why starting with a monolith is almost always the right choice, even if the end goal is microservices.

--- a/docs/architecture/adr/BE-005_monolithic-application.md
+++ b/docs/architecture/adr/BE-005_monolithic-application.md
@@ -1,0 +1,42 @@
+# BE-005 Monolithic architecture with logical boundaries
+
+## Status
+Proposed
+
+## Context
+We are currently starting promising project with four primary business areas identified so far: Users, Lecturers, Opinions, and Courses. We have already adopted Clean Architecture, lightweight Domain-Driven Design (DDD), and simple CQRS to maintain strict technical boundaries between our business logic and infrastructure.
+
+We now need to decide on the high-level deployment and structural boundary of the system. While advanced patterns like microservices or modular monoliths offer excellent long-term scalability and strict domain isolation, we must balance this against our current constraints: a small student team, the need for rapid prototyping, and the reality that our domain boundaries are still evolving and might change as we discover new requirements.
+
+## Decision
+We will build the backend as a **standard monolith with logical boundaries** (a single deployment unit and a single database context).
+
+- **Deployment:** the entire backend will be compiled and deployed as a single ASP.NET Core application.
+- **Data access:** we will use a single Entity Framework Core `DbContext` to allow for easy querying and joining of data across different business entities during our initial development phases.
+- **Organization:** while we won't enforce strict physical compilation boundaries between modules yet, we will organize our Application and Domain layers by feature or domain aggregate (e.g., grouping all Course-related Use Cases, domain entities, and interfaces in a dedicated `Courses` directory) to prepare for future extraction.
+
+## Consequences
+
+### (+):
+- **High development velocity:** developers can easily build features that span multiple domains (e.g., displaying a Course alongside its average Opinions and Lecturer details) without writing complex inter-module communication code or event buses.
+- **Operational simplicity:** a single deployable unit is trivial to host, scale horizontally (by just spinning up more instances behind a load balancer), and monitor. CI/CD pipelines remain simple and fast.
+- **Easy refactoring:** because the domain boundaries are not yet locked behind strict module interfaces, renaming, moving, or merging concepts as we learn more about the university domain is cheap and fast.
+- **Paves the way for the future:** Because we are using Clean Architecture [BE-001](docs\architecture\adr\BE-001_dependency-inversion-and-domain-isolation.md), our core logic is already decoupled from the infrastructure. This makes transitioning to a modular monolith much easier later when the project size justifies it.
+
+### (-):
+- **Risk of coupling:** without strict compiler-level enforcement, developers might become lazy and tightly couple the Opinions logic directly to the Users logic. This requires strict discipline during code reviews to ensure domain aggregates only reference each other by ID, not by direct object references.
+- **Future migration effort:** when the time comes to split into a modular monolith, we will have to carefully untangle any cross-domain database queries that we allowed early on.
+- **Single point of failure:** if one feature causes a memory leak or crashes the application, the entire API goes down.
+
+## Alternatives
+Considered options and why we rejected them:
+
+1. **Microservices architecture:** Rejected. Absolute overkill for a student project. It introduces immense distributed systems complexity (network latency, distributed tracing, eventual consistency, multiple CI/CD pipelines, container orchestration) that would completely halt our actual feature development.
+
+2. **Modular monolith:** Rejected for now. A true modular monolith requires strict data isolation (separate database schemas or contexts per module) and explicit APIs for modules to talk to each other. Given that our domains (Users, Courses, Opinions, Lecturers) are highly interconnected, implementing this from beginning would introduce too much friction. We will revisit this pattern when specific modules become large enough to warrant physical isolation.
+
+## Links to external or internal resources
+- [MonolithFirst by Martin Fowler](https://martinfowler.com/bliki/MonolithFirst.html) - Explains why starting with a monolith is almost always the right choice, even if the end goal is microservices.
+- [Modular Monolith: A Gentle Introduction by Daniel Mackay](https://www.dandoescode.com/blog/modular-monolith/a-gentle-introduction) - Outlines the benefits of the Modular Monolith pattern and the strict isolation it requires, which we will use as a reference for our future architectural roadmap.
+- [Majestic Monolith by David Heinemeier Hansson](https://m.signalvnoise.com/the-majestic-monolith/) - A defense of the monolithic architecture for small to medium-sized teams.
+- [Modular Monoliths • Simon Brown • GOTO 2018](https://www.youtube.com/watch?v=5OjqD-ow8GE)

--- a/docs/architecture/adr/BE-005_monolithic-application.md
+++ b/docs/architecture/adr/BE-005_monolithic-application.md
@@ -1,7 +1,7 @@
 # BE-005 Monolithic architecture with logical boundaries
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 We are currently starting a promising project with four primary business areas identified so far: Users, Lecturers, Opinions, and Courses. We have already adopted Clean Architecture, lightweight Domain-Driven Design (DDD), and simple CQRS to maintain strict technical boundaries between our business logic and infrastructure.


### PR DESCRIPTION
## Changes
- update ADR template
- add 5 ADR records to `docs/architecture`
- fix issue with failing CodeQL check (part of our CI pipeline) when changes don't affect client, server and actions at the same time (so it uses default `{include: []}` value). `-c` param which was added ensures that json is compact (single line). Multi line text should be saved in different way to GITHUB_OUTPUT variable.

## How to test (optional)
I recommend reading the external links in ADR first, then that ADR.

## Screenshots / recordings (for UI stuff)
...

## Checklist
- [x] PR is linked to an issue (tab on the right).
- [x] Acceptance criteria (from issue) are met.
- [x] All status checks (CI) are green.
- [x] Tests added / updated.
- [x] Docs updated (if applicable).

---
To have your PR reviewed put the link e.g. `https://github.com/akai-org/put-wiki/pull/0` to the `Review PR` thread on [put-wiki dc channel](https://discord.com/channels/768494845634412624/1467612224079007855) (you must be member of the AKAI discord server)
