### PR TITLE
feat: add JoinedDate to User

### DIFF
--- a/server/Application/DTOs/UserDto.cs
+++ b/server/Application/DTOs/UserDto.cs
@@ -1,3 +1,4 @@
-﻿namespace Application.DTOs;
+﻿using System;
+namespace Application.DTOs;
 
-public record UserDto(string Id, string HashedUsosId);
+public record UserDto(string Id, string HashedUsosId, DateTimeOffset JoinedDate);

--- a/server/Application/Users/ProvisionUserUseCase.cs
+++ b/server/Application/Users/ProvisionUserUseCase.cs
@@ -22,7 +22,8 @@ public partial class ProvisionUserUseCase(
     IUsosIdHasher hasher,
     IUserRepository userRepository,
     ILogger<ProvisionUserUseCase> logger,
-    IMapper mapper)
+    IMapper mapper,
+    TimeProvider timeProvider)
 {
 
     public async Task<Result<UserDto>> ExecuteAsync(string oauthToken, string oauthVerifier,
@@ -49,7 +50,7 @@ public partial class ProvisionUserUseCase(
             return Result.Ok(mapper.Map<UserDto>(existingUser));
         }
 
-        var newUser = new User(hashedId);
+        var newUser = new User(hashedId, timeProvider.GetUtcNow());
         userRepository.Add(newUser);
         await userRepository.SaveChangesAsync(ct);
 

--- a/server/Directory.Packages.props
+++ b/server/Directory.Packages.props
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Npgsql" Version="10.0.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />

--- a/server/Domain/Users/User.cs
+++ b/server/Domain/Users/User.cs
@@ -6,6 +6,7 @@ public class User
 {
     public Guid Id { get; private set; }
     public string HashedUsosId { get; private set; }
+    public DateTimeOffset JoinedDate { get; init; }
 
     public User(string hashedUsosId)
     {
@@ -14,5 +15,6 @@ public class User
 
         Id = Guid.CreateVersion7();
         HashedUsosId = hashedUsosId;
+        JoinedDate = DateTimeOffset.UtcNow;
     }
 }

--- a/server/Domain/Users/User.cs
+++ b/server/Domain/Users/User.cs
@@ -8,13 +8,13 @@ public class User
     public string HashedUsosId { get; private set; }
     public DateTimeOffset JoinedDate { get; init; }
 
-    public User(string hashedUsosId)
+    public User(string hashedUsosId, DateTimeOffset joinedDate)
     {
         if (string.IsNullOrWhiteSpace(hashedUsosId))
             throw new ArgumentException("Hashed USOS ID cannot be empty.");
 
         Id = Guid.CreateVersion7();
         HashedUsosId = hashedUsosId;
-        JoinedDate = DateTimeOffset.UtcNow;
+        JoinedDate = joinedDate;
     }
 }

--- a/server/Infrastructure/Extensions/InfrastructureConfiguration.cs
+++ b/server/Infrastructure/Extensions/InfrastructureConfiguration.cs
@@ -28,6 +28,8 @@ public static partial class InfrastructureConfiguration
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddSingleton<IUsosIdHasher, HmacUsosIdHasher>();
 
+        services.AddSingleton(TimeProvider.System);
+
         return services;
     }
 

--- a/server/Infrastructure/Migrations/20260606153645_AddUserJoinedDate.Designer.cs
+++ b/server/Infrastructure/Migrations/20260606153645_AddUserJoinedDate.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260606153645_AddUserJoinedDate")]
+    partial class AddUserJoinedDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/Infrastructure/Migrations/20260606153645_AddUserJoinedDate.cs
+++ b/server/Infrastructure/Migrations/20260606153645_AddUserJoinedDate.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserJoinedDate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "JoinedDate",
+                table: "Users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "JoinedDate",
+                table: "Users");
+        }
+    }
+}

--- a/server/Presentation/Program.cs
+++ b/server/Presentation/Program.cs
@@ -23,8 +23,6 @@ builder.Configuration.AddEnvironmentVariables();
 builder.Services.AddHealthChecks();
 builder.Services.AddMemoryCache();
 
-builder.Services.AddSingleton(TimeProvider.System);
-
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 
 builder.Services.AddInfrastructure(builder.Configuration);

--- a/server/Presentation/Program.cs
+++ b/server/Presentation/Program.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Application.Extensions;
 
 using Infrastructure.Extensions;
@@ -9,8 +11,6 @@ using Microsoft.Extensions.Hosting;
 
 using Presentation.Extensions;
 using Presentation.Middlewares;
-
-using System;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/server/Presentation/Program.cs
+++ b/server/Presentation/Program.cs
@@ -10,6 +10,8 @@ using Microsoft.Extensions.Hosting;
 using Presentation.Extensions;
 using Presentation.Middlewares;
 
+using System;
+
 var builder = WebApplication.CreateBuilder(args);
 
 if (builder.Environment.IsDevelopment())
@@ -20,6 +22,8 @@ if (builder.Environment.IsDevelopment())
 builder.Configuration.AddEnvironmentVariables();
 builder.Services.AddHealthChecks();
 builder.Services.AddMemoryCache();
+
+builder.Services.AddSingleton(TimeProvider.System);
 
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 

--- a/server/PutWiki.UnitTests/Application/ProvisionUserUseCaseTests.cs
+++ b/server/PutWiki.UnitTests/Application/ProvisionUserUseCaseTests.cs
@@ -17,6 +17,7 @@ using FluentAssertions;
 using FluentResults;
 
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 
 using Moq;
 
@@ -27,6 +28,7 @@ public class ProvisionUserUseCaseTests
     private readonly Mock<IUsosOAuthService> _usosOAuthServiceMock;
     private readonly Mock<IUsosIdHasher> _idHasherMock;
     private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly FakeTimeProvider _timeProviderMock;
     private readonly ProvisionUserUseCase _sut;
 
     public ProvisionUserUseCaseTests()
@@ -34,6 +36,7 @@ public class ProvisionUserUseCaseTests
         _usosOAuthServiceMock = new Mock<IUsosOAuthService>();
         _idHasherMock = new Mock<IUsosIdHasher>();
         _userRepositoryMock = new Mock<IUserRepository>();
+        _timeProviderMock = new FakeTimeProvider();
 
         var mapperConfig = new MapperConfiguration(cfg =>
         {
@@ -46,7 +49,8 @@ public class ProvisionUserUseCaseTests
             _idHasherMock.Object,
             _userRepositoryMock.Object,
             NullLogger<ProvisionUserUseCase>.Instance,
-            mapper
+            mapper,
+            _timeProviderMock
         );
     }
 
@@ -81,7 +85,8 @@ public class ProvisionUserUseCaseTests
         var verifier = "verifier";
         var rawUsosId = "12345";
         var hashedUsosId = "XYZ_HASHED_ID";
-        var existingUser = new User(hashedUsosId);
+        var fakeDate = new DateTimeOffset(2026, 6, 6, 12, 0, 0, TimeSpan.Zero);
+        var existingUser = new User(hashedUsosId, fakeDate);
         var usosUserDto = new UsosUserDto(rawUsosId);
 
         _usosOAuthServiceMock
@@ -117,7 +122,7 @@ public class ProvisionUserUseCaseTests
         var rawUsosId = "567890";
         var hashedUsosId = "ABC_HASHED_ID";
         var usosUserDto = new UsosUserDto(rawUsosId);
-
+        var fakeDate = new DateTimeOffset(2026, 6, 6, 12, 0, 0, TimeSpan.Zero);
         _usosOAuthServiceMock
             .Setup(x => x.HandleCallbackAndGetUserAsync(token, verifier, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Ok(usosUserDto));
@@ -129,7 +134,8 @@ public class ProvisionUserUseCaseTests
         _userRepositoryMock
             .Setup(x => x.GetByHashedUsosIdAsync(hashedUsosId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
-
+        
+        _timeProviderMock.SetUtcNow(fakeDate);
         // Act
         var result = await _sut.ExecuteAsync(token, verifier, CancellationToken.None);
 
@@ -138,6 +144,7 @@ public class ProvisionUserUseCaseTests
         result.Value.Should().NotBeNull();
         result.Value!.HashedUsosId.Should().Be(hashedUsosId);
         result.Value.Id.Should().NotBe(Guid.Empty.ToString());
+        result.Value.JoinedDate.Should().Be(_timeProviderMock.GetUtcNow());
 
         _userRepositoryMock.Verify(x => x.Add(It.Is<User>(u => u.HashedUsosId == hashedUsosId)), Times.Once);
         _userRepositoryMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);

--- a/server/PutWiki.UnitTests/Application/ProvisionUserUseCaseTests.cs
+++ b/server/PutWiki.UnitTests/Application/ProvisionUserUseCaseTests.cs
@@ -28,7 +28,7 @@ public class ProvisionUserUseCaseTests
     private readonly Mock<IUsosOAuthService> _usosOAuthServiceMock;
     private readonly Mock<IUsosIdHasher> _idHasherMock;
     private readonly Mock<IUserRepository> _userRepositoryMock;
-    private readonly FakeTimeProvider _timeProviderMock;
+    private readonly FakeTimeProvider _fakeTimeProvider;
     private readonly ProvisionUserUseCase _sut;
 
     public ProvisionUserUseCaseTests()
@@ -36,7 +36,7 @@ public class ProvisionUserUseCaseTests
         _usosOAuthServiceMock = new Mock<IUsosOAuthService>();
         _idHasherMock = new Mock<IUsosIdHasher>();
         _userRepositoryMock = new Mock<IUserRepository>();
-        _timeProviderMock = new FakeTimeProvider();
+        _fakeTimeProvider = new FakeTimeProvider();
 
         var mapperConfig = new MapperConfiguration(cfg =>
         {
@@ -50,7 +50,7 @@ public class ProvisionUserUseCaseTests
             _userRepositoryMock.Object,
             NullLogger<ProvisionUserUseCase>.Instance,
             mapper,
-            _timeProviderMock
+            _fakeTimeProvider
         );
     }
 
@@ -134,8 +134,8 @@ public class ProvisionUserUseCaseTests
         _userRepositoryMock
             .Setup(x => x.GetByHashedUsosIdAsync(hashedUsosId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
+        _fakeTimeProvider.SetUtcNow(fakeDate);
 
-        _timeProviderMock.SetUtcNow(fakeDate);
         // Act
         var result = await _sut.ExecuteAsync(token, verifier, CancellationToken.None);
 
@@ -144,9 +144,9 @@ public class ProvisionUserUseCaseTests
         result.Value.Should().NotBeNull();
         result.Value!.HashedUsosId.Should().Be(hashedUsosId);
         result.Value.Id.Should().NotBe(Guid.Empty.ToString());
-        result.Value.JoinedDate.Should().Be(_timeProviderMock.GetUtcNow());
+        result.Value.JoinedDate.Should().Be(fakeDate);
 
-        _userRepositoryMock.Verify(x => x.Add(It.Is<User>(u => u.HashedUsosId == hashedUsosId)), Times.Once);
+        _userRepositoryMock.Verify(x => x.Add(It.Is<User>(u => u.HashedUsosId == hashedUsosId && u.JoinedDate == fakeDate)), Times.Once);
         _userRepositoryMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/server/PutWiki.UnitTests/Application/ProvisionUserUseCaseTests.cs
+++ b/server/PutWiki.UnitTests/Application/ProvisionUserUseCaseTests.cs
@@ -134,7 +134,7 @@ public class ProvisionUserUseCaseTests
         _userRepositoryMock
             .Setup(x => x.GetByHashedUsosIdAsync(hashedUsosId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
-        
+
         _timeProviderMock.SetUtcNow(fakeDate);
         // Act
         var result = await _sut.ExecuteAsync(token, verifier, CancellationToken.None);

--- a/server/PutWiki.UnitTests/PutWiki.UnitTests.csproj
+++ b/server/PutWiki.UnitTests/PutWiki.UnitTests.csproj
@@ -3,6 +3,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="FluentResults" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />


### PR DESCRIPTION
Closes #86

## Changes
- Added `JoinedDate` property (`DateTimeOffset` type) to the `User` domain entity.
- Ensured the property is immutable (no setter / using `init`).
- Exposed the `JoinedDate` field in the Data Transfer Objects (`UserDto`).
- Generated a new EF Core database migration (`AddUserJoinedDate`).

## How to test (optional)
1. Run the database (`docker compose up database`) and the backend server (`dotnet run`).
2. Navigate to the interactive API documentation (e.g., `http://localhost:7278/docs`).
3. Scroll down to the "Models" section and check the schema for `UserDto` - the `joinedDate` field should be visible.

## Screenshots / recordings (for UI stuff)
...

## Checklist
- [x] PR is linked to an issue (tab on the right).
- [x] Acceptance criteria (from issue) are met.
- [x] All status checks (CI) are green.
- [ ] Tests added / updated.
- [ ] Docs updated (if applicable).

---
To have your PR reviewed put the link e.g. `https://github.com/akai-org/put-wiki/pull/0` to the `Review PR` thread on [put-wiki dc channel](https://discord.com/channels/768494845634412624/1467612224079007855) (you must be member of the AKAI discord server)
