### PR TITLE
feat: remove code coverage steps from ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,20 +100,6 @@ jobs:
           --no-restore \
           --collect:"XPlat Code Coverage" \
           --results-directory ./coverage
-          
-      - name: Code coverage report
-        uses: irongut/CodeCoverageSummary@v1.3.0
-        with:
-          filename: server/coverage/**/coverage.cobertura.xml
-          badge: true
-          format: markdown
-          output: both
-
-      - name: Add code coverage PR comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          recreate: true
-          path: code-coverage-results.md
   
   ci-status:
     needs: [client-verification, server-verification]


### PR DESCRIPTION
## Changes
- remove code coverage summary outputting and creating PR comments with them for backend during CI pipeline. This change is due to the fact that we simply don't aim at certain percentage of coverage and we don't use that data.

## How to test (optional)
Steps for reviewer to verify changes.

## Screenshots / recordings (for UI stuff)
...

## Checklist
- [x] PR is linked to an issue (tab on the right).
- [x] Acceptance criteria (from issue) are met.
- [x] All status checks (CI) are green.
- [x] Tests added / updated.
- [x] Docs updated (if applicable).

---
To have your PR reviewed put the link e.g. `https://github.com/akai-org/put-wiki/pull/0` to the `Review PR` thread on [put-wiki dc channel](https://discord.com/channels/768494845634412624/1467612224079007855) (you must be member of the AKAI discord server)
