### PR TITLE
fix: check types in client CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       
       - name: Install dependencies
         run: bun ci
+
+      - name: Build client and check types
+        run: bun run build
         
       - name: Check linting
         run: bun run lint:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,14 @@ jobs:
       - name: Install dependencies
         run: bun ci
 
-      - name: Build client and check types
-        run: bun run build
+      - name: Check formatting
+        run: bun run format:check
         
       - name: Check linting
         run: bun run lint:check
         
-      - name: Check formatting
-        run: bun run format:check
+      - name: Build client and check types
+        run: bun run build
         
       - name: Perform unit tests
         run: bun run test:unit


### PR DESCRIPTION
## Changes
- add new step to `client-verification` that builds the app. this is the same command that CD pipeline runs so if will catch everything that wasn't catched previously (including type errors)

## How to test (optional)
Steps for reviewer to verify changes.

## Screenshots / recordings (for UI stuff)
...

## Checklist
- [x] PR is linked to an issue (tab on the right).
- [x] Acceptance criteria (from issue) are met.
- [x] All status checks (CI) are green.
- [x] Tests added / updated.
- [x] Docs updated (if applicable).

---
To have your PR reviewed put the link e.g. `https://github.com/akai-org/put-wiki/pull/0` to the `Review PR` thread on [put-wiki dc channel](https://discord.com/channels/768494845634412624/1467612224079007855) (you must be member of the AKAI discord server)
